### PR TITLE
ENG-4143: Replicate JS behavior and allow not disabling track

### DIFF
--- a/include/Producer.hpp
+++ b/include/Producer.hpp
@@ -43,6 +43,9 @@ namespace mediasoupclient
 		  webrtc::RtpSenderInterface* rtpSender,
 		  webrtc::MediaStreamTrackInterface* track,
 		  const nlohmann::json& rtpParameters,
+		  const bool stopTracks,
+		  const bool zeroRtpOnPause,
+		  const bool disableTrackOnPause,
 		  const nlohmann::json& appData);
 
 	public:
@@ -91,6 +94,12 @@ namespace mediasoupclient
 		bool paused{ false };
 		// Video Max spatial layer.
 		uint8_t maxSpatialLayer{ 0 };
+		// Stop tracks
+		// NOTE(jpgneves) - not actually implemented, as we can't stop the tracks
+		bool stopTracks{ false };
+		// Stop sending bytes on pause
+		bool zeroRtpOnPause{ false };
+		bool disableTrackOnPause{ false };
 		// App custom data.
 		nlohmann::json appData;
 	};

--- a/include/Transport.hpp
+++ b/include/Transport.hpp
@@ -132,6 +132,9 @@ namespace mediasoupclient
 		  webrtc::MediaStreamTrackInterface* track,
 		  const std::vector<webrtc::RtpEncodingParameters>* encodings,
 		  const nlohmann::json* codecOptions,
+		  const bool stopTracks,
+		  const bool zeroRtpOnPause,
+		  const bool disableTrackOnPause,
 		  const nlohmann::json& appData = nlohmann::json::object());
 
 		DataProducer* ProduceData(

--- a/src/Producer.cpp
+++ b/src/Producer.cpp
@@ -16,9 +16,13 @@ namespace mediasoupclient
 	  webrtc::RtpSenderInterface* rtpSender,
 	  webrtc::MediaStreamTrackInterface* track,
 	  const json& rtpParameters,
+	  const bool stopTracks,
+	  const bool zeroRtpOnPause,
+	  const bool disableTrackOnPause,
 	  const json& appData)
 	  : privateListener(privateListener), listener(listener), id(id), localId(localId),
-	    rtpSender(rtpSender), track(track), rtpParameters(rtpParameters), appData(appData)
+	    rtpSender(rtpSender), track(track), rtpParameters(rtpParameters), stopTracks(stopTracks),
+	    zeroRtpOnPause(zeroRtpOnPause), disableTrackOnPause(disableTrackOnPause), appData(appData)
 	{
 		MSC_TRACE();
 	}
@@ -132,9 +136,14 @@ namespace mediasoupclient
 
 		this->paused = true;
 
-		if (this->track != nullptr)
+		if (this->track != nullptr && this->disableTrackOnPause)
 		{
 			this->track->set_enabled(false);
+		}
+
+		if (this->zeroRtpOnPause)
+		{
+			this->privateListener->OnReplaceTrack(this, nullptr);
 		}
 	}
 
@@ -154,9 +163,14 @@ namespace mediasoupclient
 
 		this->paused = false;
 
-		if (this->track != nullptr)
+		if (this->track != nullptr && this->disableTrackOnPause)
 		{
 			this->track->set_enabled(true);
+		}
+
+		if (this->zeroRtpOnPause)
+		{
+			this->privateListener->OnReplaceTrack(this, this->track);
 		}
 	}
 

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -177,6 +177,9 @@ namespace mediasoupclient
 	  webrtc::MediaStreamTrackInterface* track,
 	  const std::vector<webrtc::RtpEncodingParameters>* encodings,
 	  const json* codecOptions,
+	  const bool stopTracks,
+	  const bool zeroRtpOnPause,
+	  const bool disableTrackOnPause,
 	  const json& appData)
 	{
 		MSC_TRACE();
@@ -242,6 +245,9 @@ namespace mediasoupclient
 		  sendResult.rtpSender,
 		  track,
 		  sendResult.rtpParameters,
+		  stopTracks,
+		  zeroRtpOnPause,
+		  disableTrackOnPause,
 		  appData);
 
 		this->producers[producer->GetId()] = producer;


### PR DESCRIPTION
Adds producer options for `zeroRtpOnPause` and `disableTrackOnPause` so we can control this behavior and not disable the local track when we stop publishing.

See [here](https://github.com/versatica/mediasoup-client/blob/v3/src/Producer.ts#L285-L342) for the JS behavior.

See https://github.com/daily-co/daily-x/pull/469 for the `daily-core` change.