### PR TITLE
CSDK-484 libmediasoup unit tests

### DIFF
--- a/deps/catch/single_include/catch2/catch.hpp
+++ b/deps/catch/single_include/catch2/catch.hpp
@@ -10732,7 +10732,9 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    // NOTE(aleix): MINSIGSTKSZ is not a constant expresion so compilation
+    // fails. Commeting out for now.
+    static constexpr std::size_t sigStackSize = 32768;// >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },
@@ -17612,4 +17614,3 @@ using Catch::Detail::Approx;
 // end catch_reenable_warnings.h
 // end catch.hpp
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-

--- a/deps/libsdptransform/test/include/catch.hpp
+++ b/deps/libsdptransform/test/include/catch.hpp
@@ -10714,7 +10714,9 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    // NOTE(aleix): MINSIGSTKSZ is not a constant expresion so compilation
+    // fails. Commeting out for now.
+    static constexpr std::size_t sigStackSize = 32768; // >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },
@@ -17594,4 +17596,3 @@ using Catch::Detail::Approx;
 // end catch_reenable_warnings.h
 // end catch.hpp
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-

--- a/src/Producer.cpp
+++ b/src/Producer.cpp
@@ -80,7 +80,7 @@ namespace mediasoupclient
 	{
 		MSC_TRACE();
 
-		return this->paused;
+		return this->paused || (this->track && !this->track->enabled());
 	}
 
 	uint8_t Producer::GetMaxSpatialLayer() const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,12 @@ if(UNIX)
 	target_link_libraries(test_mediasoupclient PRIVATE Threads::Threads)
 endif(UNIX)
 
+# NOTE(aleix): This is so we can link tests in Linux using libwebrtc built as
+# explained in https://mediasoup.org/documentation/v3/libmediasoupclient/installation/
+if(UNIX AND NOT APPLE)
+	target_link_libraries(test_mediasoupclient PRIVATE glib-2.0 X11)
+endif()
+
 # Private dependencies.
 target_link_libraries(test_mediasoupclient PRIVATE mediasoupclient)
 target_link_libraries(test_mediasoupclient PRIVATE ${CMAKE_DL_LIBS})

--- a/test/src/mediasoupclient.test.cpp
+++ b/test/src/mediasoupclient.test.cpp
@@ -191,7 +191,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		/* clang-format on */
 
 		REQUIRE_NOTHROW(audioProducer.reset(
-		  sendTransport->Produce(&producerListener, audioTrack, nullptr, &codecOptions, appData)));
+		sendTransport->Produce(&producerListener, audioTrack, nullptr, &codecOptions, false, false, false, appData)));
 
 		REQUIRE(
 		  sendTransportListener.onConnectTimesCalled ==
@@ -211,7 +211,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		REQUIRE(audioProducer->GetRtpSender() != nullptr);
 		REQUIRE(audioProducer->GetTrack() == audioTrack);
 		REQUIRE(audioProducer->IsPaused());
-		REQUIRE(audioProducer->GetMaxSpatialLayer() == 0);
+		REQUIRE(audioProducer->GetMaxSpatialLayer() == 255);
 		REQUIRE(audioProducer->GetAppData() == appData);
 		REQUIRE(audioProducer->GetRtpParameters()["codecs"].size() == 1);
 
@@ -235,7 +235,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		audioProducer->Resume();
 
 		REQUIRE_NOTHROW(videoProducer.reset(
-		  sendTransport->Produce(&producerListener, videoTrack, &encodings, nullptr)));
+		sendTransport->Produce(&producerListener, videoTrack, &encodings, nullptr, false, false, false)));
 
 		REQUIRE(
 		  sendTransportListener.onConnectTimesCalled ==
@@ -305,7 +305,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 	SECTION("transport.produce() without track throws")
 	{
 		REQUIRE_THROWS_AS(
-		  sendTransport->Produce(&producerListener, nullptr, nullptr, nullptr), MediaSoupClientTypeError);
+		  sendTransport->Produce(&producerListener, nullptr, nullptr, nullptr, false, false, false), MediaSoupClientTypeError);
 	}
 
 	SECTION("transport.produceData() on transport without sctpParameters throws")
@@ -664,12 +664,13 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		videoTrack = newVideoTrack;
 	}
 
-	SECTION("producer.ReplaceTrack() fails if null track is provided")
-	{
-		REQUIRE_THROWS_AS(
-			videoProducer->ReplaceTrack(nullptr),
-			MediaSoupClientError);
-	}
+	// NOTE(aleix): We now allow null tracks.
+	// SECTION("producer.ReplaceTrack() fails if null track is provided")
+	// {
+	// 	REQUIRE_THROWS_AS(
+	// 		videoProducer->ReplaceTrack(nullptr),
+	// 		MediaSoupClientError);
+	// }
 
 	SECTION("producer.SetMaxSpatialLayer() succeeds")
 	{
@@ -766,7 +767,7 @@ TEST_CASE("mediasoupclient", "[mediasoupclient]")
 		REQUIRE_THROWS_AS(
 			sendTransport->Produce(
 				&producerListener,
-				audioTrack, nullptr, nullptr),
+				audioTrack, nullptr, nullptr, false, false, false),
 			MediaSoupClientError);
 	}
 


### PR DESCRIPTION
This fixes Unit Tests. The only trick (for now) is that we need to use libwebrtc built as explained here:

https://mediasoup.org/documentation/v3/libmediasoupclient/installation/