### PR TITLE
CSDK-534: Fix ReplaceTrack

### DIFF
--- a/src/Producer.cpp
+++ b/src/Producer.cpp
@@ -194,10 +194,10 @@ namespace mediasoupclient
 			return;
 		}
 
+		auto paused = IsPaused();
+
 		// May throw.
 		this->privateListener->OnReplaceTrack(this, track);
-
-		auto paused = IsPaused();
 
 		// Set the new track.
 		this->track = track;


### PR DESCRIPTION
The old track referenced by the producer is invalidated after `OnReplaceTrack`. All we want to do with `IsPaused` is to get the current state of the old track, so we can do it before we replace the track, thus avoiding the issue entirely.