### PR TITLE
Fixing RID exception

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -537,10 +537,17 @@ namespace mediasoupclient
 		auto parameters   = transceiver->sender()->GetParameters();
 
 		// Edit encodings.
-		for (int i = 0; i < parameters.encodings.size() && i < encodings.size(); i++)
-		{
-			parameters.encodings[i] = encodings[i];
-		}
+        for (int i = 0; i < parameters.encodings.size() && i < encodings.size(); i++)
+        {
+            auto oldEncoding = parameters.encodings[i];
+            parameters.encodings[i] = encodings[i];
+            // There are a couple of paramters that we are not allowed to change
+            // So we need to preserve this parameter before we change the encoding
+            // More info can be found inside webrtc, media_engine.cc => CheckRtpParametersInvalidModificationAndValues
+            parameters.encodings[i].rid = oldEncoding.rid;
+            parameters.encodings[i].ssrc = oldEncoding.ssrc;
+            parameters.encodings[i].active = oldEncoding.active;
+        }
 
 		auto result = transceiver->sender()->SetParameters(parameters);
 

--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -537,17 +537,18 @@ namespace mediasoupclient
 		auto parameters   = transceiver->sender()->GetParameters();
 
 		// Edit encodings.
-        for (int i = 0; i < parameters.encodings.size() && i < encodings.size(); i++)
-        {
-            auto oldEncoding = parameters.encodings[i];
-            parameters.encodings[i] = encodings[i];
-            // There are a couple of paramters that we are not allowed to change
-            // So we need to preserve this parameter before we change the encoding
-            // More info can be found inside webrtc, media_engine.cc => CheckRtpParametersInvalidModificationAndValues
-            parameters.encodings[i].rid = oldEncoding.rid;
-            parameters.encodings[i].ssrc = oldEncoding.ssrc;
-            parameters.encodings[i].active = oldEncoding.active;
-        }
+		for (int i = 0; i < parameters.encodings.size() && i < encodings.size(); i++)
+		{
+			auto oldEncoding        = parameters.encodings[i];
+			parameters.encodings[i] = encodings[i];
+			// There are a couple of parameters that we are not allowed to change
+			// So we need to preserve these parameters before we change the encoding
+			// More info can be found inside webrtc, media_engine.cc =>
+			// CheckRtpParametersInvalidModificationAndValues
+			parameters.encodings[i].rid    = oldEncoding.rid;
+			parameters.encodings[i].ssrc   = oldEncoding.ssrc;
+			parameters.encodings[i].active = oldEncoding.active;
+		}
 
 		auto result = transceiver->sender()->SetParameters(parameters);
 


### PR DESCRIPTION
Fixing the error when invoking SetRtpEncodingParameters
```
[ERROR] Handler::SetRtpEncodingParameters() | throwing MediaSoupClientError: Attempted to change RID values in the encodings.
```