### PR TITLE
Comparing int with std::vector::size_type is wrong

### DIFF
--- a/src/Handler.cpp
+++ b/src/Handler.cpp
@@ -537,7 +537,7 @@ namespace mediasoupclient
 		auto parameters   = transceiver->sender()->GetParameters();
 
 		// Edit encodings.
-		for (int i = 0; i < parameters.encodings.size() && i < encodings.size(); i++)
+		for (size_t i = 0; i < parameters.encodings.size() && i < encodings.size(); i++)
 		{
 			auto oldEncoding        = parameters.encodings[i];
 			parameters.encodings[i] = encodings[i];


### PR DESCRIPTION
Comparing `int` with `std::vector::size_type` (`size_t` in almost every case) results in a warning. The iteration should be based on `size_t` instead.